### PR TITLE
Users can choose category for the ToDo items

### DIFF
--- a/spec/persistence/sqlite.spec.js
+++ b/spec/persistence/sqlite.spec.js
@@ -6,6 +6,7 @@ const ITEM = {
     id: '7aef3d7c-d301-4846-8358-2a91ec9d6be3',
     name: 'Test',
     completed: false,
+    category: 'home',
 };
 
 beforeEach(() => {
@@ -62,4 +63,55 @@ test('it can get a single item', async () => {
 
     const item = await db.getItem(ITEM.id);
     expect(item).toEqual(ITEM);
+});
+
+test('it can store and retrieve items with category', async () => {
+    await db.init();
+
+    const itemWithCategory = { ...ITEM, category: 'work' };
+    await db.storeItem(itemWithCategory);
+
+    const items = await db.getItems();
+    expect(items.length).toBe(1);
+    expect(items[0]).toEqual(itemWithCategory);
+});
+
+test('it can update an existing item with category', async () => {
+    await db.init();
+
+    const initialItems = await db.getItems();
+    expect(initialItems.length).toBe(0);
+
+    const itemWithCategory = { ...ITEM, category: 'work' };
+    await db.storeItem(itemWithCategory);
+
+    await db.updateItem(
+        ITEM.id,
+        Object.assign({}, itemWithCategory, { completed: !ITEM.completed }),
+    );
+
+    const items = await db.getItems();
+    expect(items.length).toBe(1);
+    expect(items[0].completed).toBe(!ITEM.completed);
+    expect(items[0].category).toBe('work');
+});
+
+test('it can remove an existing item with category', async () => {
+    await db.init();
+    const itemWithCategory = { ...ITEM, category: 'work' };
+    await db.storeItem(itemWithCategory);
+
+    await db.removeItem(ITEM.id);
+
+    const items = await db.getItems();
+    expect(items.length).toBe(0);
+});
+
+test('it can get a single item with category', async () => {
+    await db.init();
+    const itemWithCategory = { ...ITEM, category: 'work' };
+    await db.storeItem(itemWithCategory);
+
+    const item = await db.getItem(ITEM.id);
+    expect(item).toEqual(itemWithCategory);
 });

--- a/spec/routes/addItem.spec.js
+++ b/spec/routes/addItem.spec.js
@@ -14,14 +14,15 @@ jest.mock('../../src/persistence', () => ({
 test('it stores item correctly', async () => {
     const id = 'something-not-a-uuid';
     const name = 'A sample item';
-    const req = { body: { name } };
+    const category = 'home';
+    const req = { body: { name, category } };
     const res = { send: jest.fn() };
 
     uuid.mockReturnValue(id);
 
     await addItem(req, res);
 
-    const expectedItem = { id, name, completed: false };
+    const expectedItem = { id, name, completed: false, category };
 
     expect(db.storeItem.mock.calls.length).toBe(1);
     expect(db.storeItem.mock.calls[0][0]).toEqual(expectedItem);

--- a/spec/routes/updateItem.spec.js
+++ b/spec/routes/updateItem.spec.js
@@ -10,7 +10,7 @@ jest.mock('../../src/persistence', () => ({
 test('it updates items correctly', async () => {
     const req = {
         params: { id: 1234 },
-        body: { name: 'New title', completed: false },
+        body: { name: 'New title', completed: false, category: 'home' },
     };
     const res = { send: jest.fn() };
 
@@ -23,6 +23,7 @@ test('it updates items correctly', async () => {
     expect(db.updateItem.mock.calls[0][1]).toEqual({
         name: 'New title',
         completed: false,
+        category: 'home',
     });
 
     expect(db.getItem.mock.calls.length).toBe(1);

--- a/src/persistence/mysql.js
+++ b/src/persistence/mysql.js
@@ -39,7 +39,7 @@ async function init() {
 
     return new Promise((acc, rej) => {
         pool.query(
-            'CREATE TABLE IF NOT EXISTS todo_items (id varchar(36), name varchar(255), completed boolean) DEFAULT CHARSET utf8mb4',
+            'CREATE TABLE IF NOT EXISTS todo_items (id varchar(36), name varchar(255), completed boolean, category varchar(255)) DEFAULT CHARSET utf8mb4',
             err => {
                 if (err) return rej(err);
 
@@ -92,8 +92,8 @@ async function getItem(id) {
 async function storeItem(item) {
     return new Promise((acc, rej) => {
         pool.query(
-            'INSERT INTO todo_items (id, name, completed) VALUES (?, ?, ?)',
-            [item.id, item.name, item.completed ? 1 : 0],
+            'INSERT INTO todo_items (id, name, completed, category) VALUES (?, ?, ?, ?)',
+            [item.id, item.name, item.completed ? 1 : 0, item.category],
             err => {
                 if (err) return rej(err);
                 acc();
@@ -105,8 +105,8 @@ async function storeItem(item) {
 async function updateItem(id, item) {
     return new Promise((acc, rej) => {
         pool.query(
-            'UPDATE todo_items SET name=?, completed=? WHERE id=?',
-            [item.name, item.completed ? 1 : 0, id],
+            'UPDATE todo_items SET name=?, completed=?, category=? WHERE id=?',
+            [item.name, item.completed ? 1 : 0, item.category, id],
             err => {
                 if (err) return rej(err);
                 acc();

--- a/src/persistence/sqlite.js
+++ b/src/persistence/sqlite.js
@@ -2,7 +2,7 @@ const sqlite3 = require('sqlite3').verbose();
 const fs = require('fs');
 const location = process.env.SQLITE_DB_LOCATION || '/etc/todos/todo.db';
 
-let db, dbAll, dbRun;
+let db, dbAll, dbUin;
 
 function init() {
     const dirName = require('path').dirname(location);
@@ -18,7 +18,7 @@ function init() {
                 console.log(`Using sqlite database at ${location}`);
 
             db.run(
-                'CREATE TABLE IF NOT EXISTS todo_items (id varchar(36), name varchar(255), completed boolean)',
+                'CREATE TABLE IF NOT EXISTS todo_items (id varchar(36), name varchar(255), completed boolean, category varchar(255))',
                 (err, result) => {
                     if (err) return rej(err);
                     acc();
@@ -70,8 +70,8 @@ async function getItem(id) {
 async function storeItem(item) {
     return new Promise((acc, rej) => {
         db.run(
-            'INSERT INTO todo_items (id, name, completed) VALUES (?, ?, ?)',
-            [item.id, item.name, item.completed ? 1 : 0],
+            'INSERT INTO todo_items (id, name, completed, category) VALUES (?, ?, ?, ?)',
+            [item.id, item.name, item.completed ? 1 : 0, item.category],
             err => {
                 if (err) return rej(err);
                 acc();
@@ -83,8 +83,8 @@ async function storeItem(item) {
 async function updateItem(id, item) {
     return new Promise((acc, rej) => {
         db.run(
-            'UPDATE todo_items SET name=?, completed=? WHERE id = ?',
-            [item.name, item.completed ? 1 : 0, id],
+            'UPDATE todo_items SET name=?, completed=?, category=? WHERE id = ?',
+            [item.name, item.completed ? 1 : 0, item.category, id],
             err => {
                 if (err) return rej(err);
                 acc();

--- a/src/routes/addItem.js
+++ b/src/routes/addItem.js
@@ -6,6 +6,7 @@ module.exports = async (req, res) => {
         id: uuid(),
         name: req.body.name,
         completed: false,
+        category: req.body.category, // P445e
     };
 
     await db.storeItem(item);

--- a/src/routes/updateItem.js
+++ b/src/routes/updateItem.js
@@ -4,6 +4,7 @@ module.exports = async (req, res) => {
     await db.updateItem(req.params.id, {
         name: req.body.name,
         completed: req.body.completed,
+        category: req.body.category, // Pc789
     });
     const item = await db.getItem(req.params.id);
     res.send(item);

--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -37,3 +37,15 @@ body {
 button:focus {
     border: 1px solid #333;
 }
+
+.category-label.home {
+    color: blue;
+}
+
+.category-label.hobbies {
+    color: green;
+}
+
+.category-label.work {
+    color: red;
+}

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -71,6 +71,7 @@ function AddItemForm({ onNewItem }) {
     const { Form, InputGroup, Button } = ReactBootstrap;
 
     const [newItem, setNewItem] = React.useState('');
+    const [category, setCategory] = React.useState('home');
     const [submitting, setSubmitting] = React.useState(false);
 
     const submitNewItem = e => {
@@ -78,7 +79,7 @@ function AddItemForm({ onNewItem }) {
         setSubmitting(true);
         fetch('/items', {
             method: 'POST',
-            body: JSON.stringify({ name: newItem }),
+            body: JSON.stringify({ name: newItem, category }),
             headers: { 'Content-Type': 'application/json' },
         })
             .then(r => r.json())
@@ -86,6 +87,7 @@ function AddItemForm({ onNewItem }) {
                 onNewItem(item);
                 setSubmitting(false);
                 setNewItem('');
+                setCategory('home');
             });
     };
 
@@ -99,6 +101,16 @@ function AddItemForm({ onNewItem }) {
                     placeholder="New Item"
                     aria-describedby="basic-addon1"
                 />
+                <Form.Control
+                    as="select"
+                    value={category}
+                    onChange={e => setCategory(e.target.value)}
+                    className="ml-2"
+                >
+                    <option value="home">Home</option>
+                    <option value="hobbies">Hobbies</option>
+                    <option value="work">Work</option>
+                </Form.Control>
                 <InputGroup.Append>
                     <Button
                         type="submit"
@@ -123,6 +135,7 @@ function ItemDisplay({ item, onItemUpdate, onItemRemoval }) {
             body: JSON.stringify({
                 name: item.name,
                 completed: !item.completed,
+                category: item.category,
             }),
             headers: { 'Content-Type': 'application/json' },
         })
@@ -158,8 +171,11 @@ function ItemDisplay({ item, onItemUpdate, onItemRemoval }) {
                         />
                     </Button>
                 </Col>
-                <Col xs={10} className="name">
+                <Col xs={9} className="name">
                     {item.name}
+                </Col>
+                <Col xs={1} className={`category-label ${item.category}`}>
+                    {item.category}
                 </Col>
                 <Col xs={1} className="text-center remove">
                     <Button


### PR DESCRIPTION
Related to #5

Add category selection for ToDo items.

* Modify `src/persistence/sqlite.js` and `src/persistence/mysql.js` to include `category` field in the database schema and update relevant functions to handle the new field.
* Update `src/routes/addItem.js` and `src/routes/updateItem.js` to include `category` field in the item object.
* Enhance `src/static/js/app.js` to add a category selection dropdown in the `AddItemForm` component, update `submitNewItem` function to include `category` field, and display category label next to the item name in the `ItemDisplay` component.
* Add CSS classes for category labels with different colors in `src/static/css/styles.css`.
* Update tests in `spec/persistence/sqlite.spec.js`, `spec/routes/addItem.spec.js`, and `spec/routes/updateItem.spec.js` to include `category` field and add tests for storing, retrieving, updating, and removing items with `category` field.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jtluoto/copilot-todo-list/pull/6?shareId=d0aeb547-c90c-474b-b82b-b283c227a30e).